### PR TITLE
Add custom request method

### DIFF
--- a/src/vmod_curl.c
+++ b/src/vmod_curl.c
@@ -36,6 +36,7 @@ struct vmod_curl {
 #define VC_VERIFY_HOST (1 << 1)
 	const char	*url;
 	const char	*method;
+	const char	*custom_method;
 	const char	*postfields;
 	const char	*error;
 	const char	*cafile;
@@ -225,6 +226,10 @@ static void cm_perform(struct vmod_curl *c) {
 		curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS, c->postfields);
 
 	}
+	if (c->custom_method) {
+		curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, c->custom_method);
+
+	}
 	if (req_headers)
 		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, req_headers);
 	curl_easy_setopt(curl_handle, CURLOPT_URL, c->url);
@@ -307,6 +312,13 @@ void vmod_post(struct sess *sp, const char *url, const char *postfields) {
 	c->url = url;
 	c->method = "POST";
 	c->postfields = postfields;
+	cm_perform(c);
+}
+
+void vmod_custom_method(struct sess *sp, const char *method) {
+	struct vmod_curl *c;
+	c = cm_get(sp);
+	c->custom_method = method;
 	cm_perform(c);
 }
 

--- a/src/vmod_curl.vcc
+++ b/src/vmod_curl.vcc
@@ -11,6 +11,11 @@ Function VOID fetch(STRING)
 # the second
 Function VOID post(STRING, STRING)
 
+# Use this before GET/HEAD/POST to overrid the method sent
+# libcurl will still behave as if you called get/head/post
+# (see CURLOPT_CUSTOMREQUEST)
+Function VOID custom_method(STRING)
+
 # Return the header named in the first argument
 Function STRING header(STRING)
 


### PR DESCRIPTION
This should take care of issue #5.

Basically adds a new `custom_method( STRING )` function that accepts the method you would like to send instead of the standard GET/HEAD/POST.

After running it you still have to call the normal get/head/post methods since that defines which code path libcurl will take per the docs.

See CURLOPT_CUSTOMREQUEST on http://curl.haxx.se/libcurl/c/curl_easy_setopt.html

Example:

``` ruby
# send a PURGE request
# libcurl will use still perform a normal get()
# but use PURGE as the request method
curl.custom_method("PURGE");
curl.get("http://example.com/uri");
```
