### PR TITLE
Fixed autogen.sh error "configure.ac:6: error: 'AM_CONFIG_HEADER': this macro is obsolete."

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_COPYRIGHT([Copyright (c) 2011 Varnish Software AS])
 AC_INIT([libvmod-curl], [0.2])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(src/vmod_curl.vcc)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 AC_CANONICAL_SYSTEM
 AC_LANG(C)


### PR DESCRIPTION
Hi

I had the following error while trying to compile on OSX:

``` bash
$ ./autogen.sh
+ glibtoolize --copy --force
glibtoolize: putting auxiliary files in `.'.
glibtoolize: copying file `./ltmain.sh'
glibtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
glibtoolize: copying file `m4/libtool.m4'
glibtoolize: copying file `m4/ltoptions.m4'
glibtoolize: copying file `m4/ltsugar.m4'
glibtoolize: copying file `m4/ltversion.m4'
glibtoolize: copying file `m4/lt~obsolete.m4'
+ aclocal -I m4
configure.ac:6: error: 'AM_CONFIG_HEADER': this macro is obsolete.
    You should use the 'AC_CONFIG_HEADERS' macro instead.
/opt/local/share/aclocal-1.13/obsolete-err.m4:12: AM_CONFIG_HEADER is expanded from...
configure.ac:6: the top level
autom4te: /opt/local/bin/gm4 failed with exit status: 1
aclocal: error: echo failed with exit status: 1
```

So I just replaced AM_CONFIG_HEADER by AC_CONFIG_HEADERS macro in `configure.ac`.

Only tested on OSX 10.8 :blush: 

Hope this helps :smiley: 
