### PR TITLE
Optimization of libcurl usage (not releasing curl_handle at every request)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libvmod-curl (0.6~b1) unstable; urgency=low
+
+  * Optimization of libcurl usage (not releasing curl_handle at every request)
+
+ -- Stéphane PIEL <stephane.piel@softeam.fr>  Wed, 15 Oct 2014 16:00:00 +0200
+
 libvmod-curl (0.1) unstable; urgency=low
 
   * First version

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: libvmod-curl
 Section: web
 Priority: extra
 Maintainer: Lasse Karstensen <lkarsten@varnish-software.com>
-Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev
+Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev, dh-autoreconf, libvarnishapi-dev (>= 4.0.0)
 Standards-Version: 3.8.1
 Vcs-Git: git://github.com/varnish/libvmod-curl.git
 
-Package: libvmod-curl
+Package: libvmod-curl-varnish4
 Architecture: any
-Depends: varnish, ${misc:Depends}
+Depends: varnish (>= 4.0.0), ${shlibs:Depends}, ${misc:Depends}
 Description: CURL for Varnish VCL

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@ override_dh_gencontrol:
 	fi
 
 %:
-	dh $@
+	dh $@ --with autoreconf

--- a/src/vmod_curl.vcc
+++ b/src/vmod_curl.vcc
@@ -2,47 +2,49 @@ $Module curl 3
 $Init init_function
 
 # GET the URL in the first parameter
-$Function VOID get(STRING)
+$Function VOID get(PRIV_VCL,STRING)
 
 # HEAD the URL in the first parameter
-$Function VOID head(STRING)
+$Function VOID head(PRIV_VCL,STRING)
 
 # Compatibility name for get
-$Function VOID fetch(STRING)
+$Function VOID fetch(PRIV_VCL,STRING)
 
 # POST the URL in the first parameter with the body fields given in
 # the second
-$Function VOID post(STRING, STRING)
+$Function VOID post(PRIV_VCL,STRING, STRING)
 
 # Return the header named in the first argument
-$Function STRING header(STRING)
+$Function STRING header(PRIV_VCL,STRING)
 
 # Free the memory used by headers. Not needed, will be handled
 # automatically if it's not called.
-$Function VOID free()
+$Function VOID free(PRIV_VCL)
 
 # The HTTP status code
-$Function INT status()
+$Function INT status(PRIV_VCL)
 
-$Function STRING error()
-$Function STRING body()
+$Function STRING error(PRIV_VCL)
+$Function STRING body(PRIV_VCL)
 
-$Function VOID set_timeout(INT)
-$Function VOID set_connect_timeout(INT)
+$Function VOID set_timeout(PRIV_VCL,INT)
+$Function VOID set_connect_timeout(PRIV_VCL,INT)
 
-$Function VOID set_ssl_verify_peer(INT)
-$Function VOID set_ssl_verify_host(INT)
-$Function VOID set_ssl_cafile(STRING)
-$Function VOID set_ssl_capath(STRING)
+$Function VOID set_ssl_verify_peer(PRIV_VCL,INT)
+$Function VOID set_ssl_verify_host(PRIV_VCL,INT)
+$Function VOID set_ssl_cafile(PRIV_VCL,STRING)
+$Function VOID set_ssl_capath(PRIV_VCL,STRING)
 
-$Function STRING escape(STRING)
-$Function STRING unescape(STRING)
+$Function STRING escape(PRIV_VCL,STRING)
+$Function STRING unescape(PRIV_VCL,STRING)
 
 # Add / Remove request headers
-$Function VOID header_add(STRING)
-$Function VOID header_remove(STRING)
+$Function VOID header_add(PRIV_VCL,STRING)
+$Function VOID header_remove(PRIV_VCL,STRING)
 
-$Function VOID proxy(STRING)
+$Function VOID proxy(PRIV_VCL,STRING)
 
-$Function VOID set_proxy(STRING)
-$Function VOID set_method(STRING)
+$Function VOID set_proxy(PRIV_VCL,STRING)
+$Function VOID set_method(PRIV_VCL,STRING)
+
+$Function VOID set_curl_handle_max_usage_count(INT)


### PR DESCRIPTION
Hello, 

Here is an optimization I've made on this libcurl vmod. I've used the ability offered by libcurl to reuse a curl_handle for multiple requests. It allows to keep active connections, DNS cache, etc... , thus improving performances.
Tested/used with varnish 4.0.2

Hope you will find this helpful.
Regards,