### PR TITLE
The asynchronous, non-blocking cURL calls using multi interface and libuv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
 # Check for pkg-config
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([CURL], [libcurl])
+PKG_CHECK_MODULES([UV], [libuv])
 
 # Checks for header files.
 AC_HEADER_STDC
@@ -54,6 +55,8 @@ AC_PATH_PROG([VARNISHD], [varnishd])
 # check if curl supports ms timeout settings
 save_CFLAGS="${CFLAGS}"
 save_LIBS="${LIBS}"
+CURL_CFLAGS="${CURL_CFLAGS} ${UV_CFLAGS}"
+CURL_LIBS="${CURL_LIBS} ${UV_LIBS}"
 CFLAGS="${CFLAGS} ${CURL_CFLAGS}"
 LIBS="${LIBS} ${CURL_LIBS}"
 AC_CACHE_CHECK([for curl ms timeout settings],

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libvmod-curl (0.2) unstable; urgency=low
+
+  * Added dependency for libuv
+
+ -- Waldek Kozba <100assc@gmail.com>  Thu, 13 Nov 2014 15:22:46 +0100
+
 libvmod-curl (0.1) unstable; urgency=low
 
   * First version

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libvmod-curl
 Section: web
 Priority: extra
 Maintainer: Lasse Karstensen <lkarsten@varnish-software.com>
-Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev
+Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev, libuv-dev
 Standards-Version: 3.8.1
 Vcs-Git: git://github.com/varnish/libvmod-curl.git
 

--- a/src/tests/test09.vtc
+++ b/src/tests/test09.vtc
@@ -1,0 +1,58 @@
+varnishtest "Test asynchronous capability"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+server s2 {
+	rxreq
+	# simulate long running task
+	delay 1.1
+	txresp -hdr "Foo: bar"
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import curl from "${vmod_topbuild}/src/.libs/libvmod_curl.so";
+
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+
+	sub vcl_recv {
+		curl.get("http://${s2_addr}:${s2_port}/curl");
+		std.timestamp("some_operation");
+		return(pass);
+	}
+
+	sub vcl_deliver {
+		# first call to any of response related functions
+		# checks/waits for the curl response
+		set resp.http.x-status = curl.status();
+		set resp.http.x-header = curl.header("Foo");
+		curl.free();
+		std.timestamp("curl_task_finished");
+	}
+
+} -start
+
+logexpect l1 -v v1 -g request {
+	# the 'some_operation' starts almost instantly
+	# and can perform simultaneously
+	expect	* 1001	Timestamp	{some_operation: \S+ 0\.\d+ 0\.\d+}
+
+	# over one second delay (caused by waiting for the curl response)
+	expect	* = 	Timestamp	{curl_task_finished: \S+ 1\.\d+ 1\.\d+}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.x-status == 200
+	expect resp.http.x-header == "bar"
+} -run
+
+logexpect l1 -wait

--- a/src/tests/test10.vtc
+++ b/src/tests/test10.vtc
@@ -1,0 +1,57 @@
+varnishtest "Test 'fire & forget'"
+
+server s1 {
+	rxreq
+	txresp
+} -start
+
+server s2 {
+	# the cURL request
+	rxreq
+	# simulate long running task
+	delay 1.1
+	expect req.method == "POST"
+	expect req.url == "/curl"
+	expect req.http.Content-Type == "text/plain"
+	expect req.bodylen == 9
+	txresp
+} -start
+
+varnish v1 -vcl {
+	import std;
+	import curl from "${vmod_topbuild}/src/.libs/libvmod_curl.so";
+
+	backend default {
+		.host = "${s1_addr}";
+		.port = "${s1_port}";
+	}
+
+	sub vcl_deliver {
+		std.timestamp("some_operation");
+		curl.set_no_wait(1);
+		curl.header_add("Content-Type: text/plain");
+		curl.post("http://${s2_addr}:${s2_port}/curl", "TEST_BODY");
+		# status is always "0" in no wait mode
+		set resp.http.x-status = curl.status();
+		curl.free();
+		std.timestamp("curl_call_finished");
+	}
+
+} -start
+
+logexpect l1 -v v1 -g request {
+	# both should appear in < 1 sec.
+	expect	* 1001	Timestamp	{some_operation: \S+ 0\.\d+ 0\.\d+}
+	expect	* = 	Timestamp	{curl_call_finished: \S+ 0\.\d+ 0\.\d+}
+} -start
+
+client c1 {
+	txreq -url "/"
+	rxresp
+	expect resp.status == 200
+	expect resp.http.x-status == 0
+} -run
+
+logexpect l1 -wait
+
+server s2 -wait

--- a/src/vmod_curl.c
+++ b/src/vmod_curl.c
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <stddef.h>
 #include <string.h>
+#include <uv.h>
 
 #include "vrt.h"
 #include "vsb.h"
@@ -45,6 +46,26 @@ struct vmod_curl {
 	VTAILQ_HEAD(, req_hdr) req_headers;
 	const char *proxy;
 	struct vsb *body;
+	int no_wait;
+	int performing;
+	pthread_mutex_t mtx;
+	pthread_cond_t cond;
+};
+
+/* The libuv socket event context */
+struct socket_context {
+	unsigned magic;
+#define VMOD_SOCKET_CONTEXT_MAGIC 0xBBB0C87D
+	uv_poll_t poll_handle;
+	curl_socket_t sockfd;
+};
+
+/* the curl easy call context */
+struct curl_context {
+	unsigned magic;
+#define VMOD_CURL_CONTEXT_MAGIC 0xBBB0C87E
+	struct vmod_curl *c;
+	struct curl_slist *req_headers;
 };
 
 static int initialised = 0;
@@ -52,7 +73,21 @@ static int initialised = 0;
 static struct vmod_curl **vmod_curl_list;
 int vmod_curl_list_sz;
 static pthread_mutex_t cl_mtx = PTHREAD_MUTEX_INITIALIZER;
+
+/* the libuv event loop related stuff */
+static pthread_mutex_t gl_mtx = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gl_cond = PTHREAD_COND_INITIALIZER;
+static uv_loop_t *loop;
+static uv_timer_t timeout;
+static uv_async_t async;
+static int callback_running = 0;
+
+/* the singleton CURL multi handle */
+static CURLM *multi_handle;
+
 static void cm_clear(struct vmod_curl *c);
+
+static void start_event_loop(void);
 
 static void
 cm_init(struct vmod_curl *c)
@@ -62,6 +97,10 @@ cm_init(struct vmod_curl *c)
 	VTAILQ_INIT(&c->req_headers);
 	c->body = VSB_new_auto();
 	cm_clear(c);
+	AZ(pthread_mutex_init(&c->mtx, NULL));
+	AZ(pthread_cond_init(&c->cond, NULL));
+	c->performing = 0;
+	c->no_wait = 0;
 }
 
 static void
@@ -128,10 +167,11 @@ cm_clear(struct vmod_curl *c)
 	c->proxy = NULL;
 	c->status = 0;
 	c->vxid = 0;
+	c->no_wait = 0;
 }
 
 static struct vmod_curl *
-cm_get(const struct vrt_ctx *ctx)
+cm_get_reserve(const struct vrt_ctx *ctx, int reserve_for_call)
 {
 	struct vmod_curl *cm;
 
@@ -156,7 +196,29 @@ cm_get(const struct vrt_ctx *ctx)
 		cm->vxid = ctx->req->sp->vxid;
 	}
 	AZ(pthread_mutex_unlock(&cl_mtx));
+	/*	Following sync block affects only this 'cm' instance.
+		It's necessary because the request, which previously
+		used this 'cm' (vmod_curl) instance could finish
+		faster then the curl easy preparation
+		in the 'no_wait' mode, and this 'cm' instance
+		could be reused by current request while still
+		not ready for that.
+	*/
+	AZ(pthread_mutex_lock(&cm->mtx));
+	while (cm->performing) {
+		AZ(pthread_cond_wait(&cm->cond, &cm->mtx));
+	}
+	if (reserve_for_call) {
+		cm_clear_fetch_state(cm);
+		cm->performing = 1;
+	}
+	AZ(pthread_mutex_unlock(&cm->mtx));
 	return (cm);
+}
+
+static struct vmod_curl *
+cm_get(const struct vrt_ctx *ctx) {
+	return cm_get_reserve(ctx, 0);
 }
 
 int
@@ -180,7 +242,8 @@ init_function(struct vmod_priv *priv, const struct VCL_conf *conf)
 		vmod_curl_list[i] = malloc(sizeof(struct vmod_curl));
 		cm_init(vmod_curl_list[i]);
 	}
-	return (curl_global_init(CURL_GLOBAL_ALL));
+	start_event_loop();
+	return 0;
 }
 
 static size_t
@@ -241,34 +304,46 @@ cm_perform(struct vmod_curl *c)
 {
 	CURL *curl_handle;
 	CURLcode cr;
-	struct curl_slist *req_headers = NULL;
+	struct curl_context *ctx;
 	struct req_hdr *rh;
+
+	ALLOC_OBJ(ctx, VMOD_CURL_CONTEXT_MAGIC);
+	AN(ctx);
 
 	curl_handle = curl_easy_init();
 	AN(curl_handle);
 
 	VTAILQ_FOREACH(rh, &c->req_headers, list)
-		req_headers = curl_slist_append(req_headers, rh->value);
+		ctx->req_headers = curl_slist_append(ctx->req_headers, rh->value);
 
 	if (c->flags & F_METHOD_POST) {
 		curl_easy_setopt(curl_handle, CURLOPT_POST, 1L);
-		curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS,
-		    c->postfields);
+		if (c->no_wait)
+			curl_easy_setopt(curl_handle, CURLOPT_COPYPOSTFIELDS,
+				c->postfields);
+		else
+			curl_easy_setopt(curl_handle, CURLOPT_POSTFIELDS,
+				c->postfields);
 	} else if (c->flags & F_METHOD_HEAD)
 		curl_easy_setopt(curl_handle, CURLOPT_NOBODY, 1L);
 	else if (c->flags & F_METHOD_GET)
 		curl_easy_setopt(curl_handle, CURLOPT_HTTPGET, 1L);
 
-	if (req_headers)
-		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, req_headers);
+	if (ctx->req_headers)
+		curl_easy_setopt(curl_handle, CURLOPT_HTTPHEADER, ctx->req_headers);
 
 	curl_easy_setopt(curl_handle, CURLOPT_URL, c->url);
 	curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
 	curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 1L);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, recv_data);
-	curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, c);
-	curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, recv_hdrs);
-	curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, c);
+
+	if (!c->no_wait) {
+		curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, recv_data);
+		curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, c);
+		curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, recv_hdrs);
+		curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, c);
+		ctx->c = c;
+	}
+	curl_easy_setopt(curl_handle, CURLOPT_PRIVATE, ctx);
 
 	if (c->proxy)
 		curl_easy_setopt(curl_handle, CURLOPT_PROXY, c->proxy);
@@ -311,22 +386,243 @@ cm_perform(struct vmod_curl *c)
 
 	curl_easy_setopt(curl_handle, CURLOPT_CUSTOMREQUEST, c->method);
 
-	cr = curl_easy_perform(curl_handle);
-
-	if (cr != 0)
-		c->error = curl_easy_strerror(cr);
-
-	curl_easy_getinfo(curl_handle, CURLINFO_RESPONSE_CODE, &c->status);
-
-	if (req_headers)
-		curl_slist_free_all(req_headers);
-
-	c->method = NULL;
-
 	cm_clear_req_headers(c);
-	curl_easy_cleanup(curl_handle);
-	VSB_finish(c->body);
+
+	if (c->no_wait) {
+		VSB_finish(c->body);
+		c->method = NULL;
+		AZ(pthread_mutex_lock(&c->mtx));
+		c->performing = 0;
+		AZ(pthread_cond_signal(&c->cond));
+		AZ(pthread_mutex_unlock(&c->mtx));
+	}
+
+	AZ(curl_multi_add_handle(multi_handle, curl_handle));
 }
+
+/*============= CURL MULTI ==============*/
+
+/*creates the libuv socket context*/
+static struct socket_context*
+libuv_create_socket_context(curl_socket_t sockfd)
+{
+	struct socket_context *context;
+
+	ALLOC_OBJ(context, VMOD_SOCKET_CONTEXT_MAGIC);
+	CHECK_OBJ_NOTNULL(context, VMOD_SOCKET_CONTEXT_MAGIC);
+
+	context->sockfd = sockfd;
+
+	uv_poll_init_socket(loop, &context->poll_handle, sockfd);
+	context->poll_handle.data = context;
+
+	return context;
+}
+
+static void
+libuv_socket_close_cb(uv_handle_t *handle)
+{
+	FREE_OBJ((struct socket_context*) handle->data);
+}
+
+static void
+libuv_destroy_socket_context(struct socket_context* context)
+{
+	uv_close((uv_handle_t*) &context->poll_handle,
+		libuv_socket_close_cb);
+}
+
+/*checks easy transfers states*/
+static void
+multi_check_easy_transfers(void)
+{
+	char *done_url;
+	CURLMsg *message;
+	int pending;
+	struct curl_context *ctx;
+	while ((message = curl_multi_info_read(multi_handle, &pending))) {
+		switch (message->msg) {
+			case CURLMSG_DONE:
+				curl_easy_getinfo(message->easy_handle,
+					CURLINFO_PRIVATE, &ctx);
+				AN(ctx);
+				if (ctx->c) {
+					AZ(curl_easy_getinfo(message->easy_handle,
+						CURLINFO_RESPONSE_CODE, &ctx->c->status));
+					if (message->data.result != 0) {
+						ctx->c->error = curl_easy_strerror(message->data.result);
+						ctx->c->status = 0;
+					}
+					VSB_finish(ctx->c->body);
+					ctx->c->method = NULL;
+				}
+				AZ(curl_multi_remove_handle(multi_handle, message->easy_handle));
+				if (ctx->req_headers)
+					curl_slist_free_all(ctx->req_headers);
+				curl_easy_cleanup(message->easy_handle);
+				if (ctx->c) {
+					AZ(pthread_mutex_lock(&ctx->c->mtx));
+					ctx->c->performing = 0;
+					AZ(pthread_cond_signal(&ctx->c->cond));
+					AZ(pthread_mutex_unlock(&ctx->c->mtx));
+				}
+				FREE_OBJ(ctx);
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+/*libuv socket event callback*/
+static void
+libuv_socket_cb(uv_poll_t *req, int status, int events)
+{
+	int running_handles;
+	int flags = 0;
+	struct socket_context *context;
+	char *done_url;
+	CURLMsg *message;
+	int pending;
+
+	uv_timer_stop(&timeout);
+
+	if (events & UV_READABLE)
+		flags |= CURL_CSELECT_IN;
+	if (events & UV_WRITABLE)
+		flags |= CURL_CSELECT_OUT;
+
+	CAST_OBJ_NOTNULL(context, req->data, VMOD_SOCKET_CONTEXT_MAGIC);
+
+	curl_multi_socket_action(multi_handle, context->sockfd, flags,
+	                       &running_handles);
+
+	multi_check_easy_transfers();
+}
+
+/*libuv timeout event callback*/
+static void
+libuv_timeout_cb(uv_timer_t *req, int status)
+{
+	int running_handles;
+	curl_multi_socket_action(multi_handle, CURL_SOCKET_TIMEOUT, 0,
+	                       &running_handles);
+	multi_check_easy_transfers();
+}
+
+/*curl multi timeout event callback*/
+static void
+multi_timeout_cb(CURLM *multi, long timeout_ms, void *userp)
+{
+	if (timeout_ms <= 0)
+		timeout_ms = 1;
+	uv_timer_start(&timeout, (uv_timer_cb) libuv_timeout_cb, timeout_ms, 0);
+}
+
+/*curl multi socket callback*/
+static int
+multi_socket_cb(CURL *easy, curl_socket_t s, int action, void *userp,
+                  void *socketp)
+{
+	struct socket_context *context;
+	if (action == CURL_POLL_IN || action == CURL_POLL_OUT) {
+		if (socketp)
+			CAST_OBJ_NOTNULL(context, socketp, VMOD_SOCKET_CONTEXT_MAGIC);
+		else
+			context = libuv_create_socket_context(s);
+		curl_multi_assign(multi_handle, s, (void *) context);
+	}
+
+	switch (action) {
+		case CURL_POLL_IN:
+			uv_poll_start(&context->poll_handle, UV_READABLE, libuv_socket_cb);
+			break;
+		case CURL_POLL_OUT:
+			uv_poll_start(&context->poll_handle, UV_WRITABLE, libuv_socket_cb);
+			break;
+		case CURL_POLL_REMOVE:
+			if (socketp) {
+				CAST_OBJ_NOTNULL(context, socketp, VMOD_SOCKET_CONTEXT_MAGIC);
+				uv_poll_stop(&context->poll_handle);
+				libuv_destroy_socket_context(context);
+				curl_multi_assign(multi_handle, s, NULL);
+			}
+			break;
+		default:
+			abort();
+	}
+	return 0;
+}
+
+/*the async event callback (triggered by a signal from the varnish request thread)*/
+static void
+libuv_async_cb(uv_async_t *handle, int status)
+{
+	struct vmod_curl *c;
+
+	CAST_OBJ_NOTNULL(c, handle->data, VMOD_CURL_MAGIC);
+
+	cm_perform(c);
+
+	AZ(pthread_mutex_lock(&gl_mtx));
+	callback_running = 0;
+	AZ(pthread_cond_signal(&gl_cond));
+	AZ(pthread_mutex_unlock(&gl_mtx));
+}
+
+/*the pthread worker running the libuv loop*/
+static void*
+multi_curl_worker(void* ptr)
+{
+	CURLcode code;
+
+	loop = uv_default_loop();
+	AN(loop);
+
+	uv_timer_init(loop, &timeout);
+	uv_async_init(loop, &async, (uv_async_cb)libuv_async_cb);
+
+	AZ(curl_global_init(CURL_GLOBAL_ALL));
+
+	multi_handle = curl_multi_init();
+	AN(multi_handle);
+	AZ(curl_multi_setopt(multi_handle, CURLMOPT_SOCKETFUNCTION, multi_socket_cb));
+	AZ(curl_multi_setopt(multi_handle, CURLMOPT_TIMERFUNCTION, multi_timeout_cb));
+	AZ(uv_run(loop, UV_RUN_DEFAULT));
+}
+
+/*starts the libuv event loop in a dedicated thread.*/
+static void
+start_event_loop(void)
+{
+	pthread_t loop_thread = NULL;
+	int result = INT_MAX;
+	AZ(pthread_create(&loop_thread, NULL, &multi_curl_worker, &result));
+	AN(loop_thread);
+}
+
+/*signals the loop thread to perform a new curl call
+*/
+static void
+cm_perform_async(struct vmod_curl *c)
+{
+	/* NOTE: uv_async_send call needs to be
+	   synchronized, otherwise, especially in high load conditions
+	   events can cumulate and the callback can be called
+	   only once per such a cumulated group.
+	   See: http://nikhilm.github.io/uvbook/threads.html#inter-thread-communication
+	*/
+	AZ(pthread_mutex_lock(&gl_mtx));
+	while (callback_running) {
+		AZ(pthread_cond_wait(&gl_cond, &gl_mtx));
+	}
+	callback_running = 1;
+	async.data = c;
+	uv_async_send(&async);
+	AZ(pthread_mutex_unlock(&gl_mtx));
+}
+
+/*============= EOF CURL MULTI ==========*/
 
 VCL_VOID
 vmod_fetch(const struct vrt_ctx *ctx, VCL_STRING url)
@@ -338,55 +634,57 @@ VCL_VOID
 vmod_get(const struct vrt_ctx *ctx, VCL_STRING url)
 {
 	struct vmod_curl *c;
-	c = cm_get(ctx);
-	cm_clear_fetch_state(c);
+	c = cm_get_reserve(ctx, 1);
 	c->url = url;
 	c->flags |= F_METHOD_GET;
-	cm_perform(c);
+	cm_perform_async(c);
 }
 
 VCL_VOID
 vmod_head(const struct vrt_ctx *ctx, VCL_STRING url)
 {
 	struct vmod_curl *c;
-	c = cm_get(ctx);
-	cm_clear_fetch_state(c);
+	c = cm_get_reserve(ctx, 1);
 	c->url = url;
 	c->flags |= F_METHOD_HEAD;
-	cm_perform(c);
+	cm_perform_async(c);
 }
 
 VCL_VOID
 vmod_post(const struct vrt_ctx *ctx, VCL_STRING url, VCL_STRING postfields)
 {
 	struct vmod_curl *c;
-	c = cm_get(ctx);
-	cm_clear_fetch_state(c);
+	c = cm_get_reserve(ctx, 1);
 	c->url = url;
 	c->flags |= F_METHOD_POST;
 	c->postfields = postfields;
-	cm_perform(c);
+	cm_perform_async(c);
 }
 
 VCL_INT
 vmod_status(const struct vrt_ctx *ctx)
 {
-	return (cm_get(ctx)->status);
+	struct vmod_curl *c;
+	c = cm_get(ctx);
+	if (c->no_wait)
+		return 0;
+	return (c->status);
 }
 
 VCL_VOID
 vmod_free(const struct vrt_ctx *ctx)
 {
-	cm_clear(cm_get(ctx));
+	struct vmod_curl *c;
+	c = cm_get(ctx);
+	cm_clear(c);
 }
 
 VCL_STRING
 vmod_error(const struct vrt_ctx *ctx)
 {
 	struct vmod_curl *c;
-
 	c = cm_get(ctx);
-	if (c->status != 0)
+	if (c->status != 0 || c->no_wait)
 		return (NULL);
 	return (c->error);
 }
@@ -400,6 +698,9 @@ vmod_header(const struct vrt_ctx *ctx, VCL_STRING header)
 
 	c = cm_get(ctx);
 
+	if (c->status == 0 || c->no_wait)
+		return (NULL);
+
 	VTAILQ_FOREACH(h, &c->headers, list) {
 		if (strcasecmp(h->key, header) == 0) {
 			r = h->value;
@@ -412,7 +713,11 @@ vmod_header(const struct vrt_ctx *ctx, VCL_STRING header)
 VCL_STRING
 vmod_body(const struct vrt_ctx *ctx)
 {
-	return (VSB_data(cm_get(ctx)->body));
+	struct vmod_curl *c;
+	c = cm_get(ctx);
+	if (c->status == 0 || c->no_wait)
+		return (NULL);
+	return (VSB_data(c->body));
 }
 
 VCL_VOID
@@ -548,4 +853,10 @@ VCL_VOID
 vmod_set_method(const struct vrt_ctx *ctx, VCL_STRING name)
 {
 	cm_get(ctx)->method = name;
+}
+
+VCL_VOID
+vmod_set_no_wait(const struct vrt_ctx *ctx, VCL_INT no_wait)
+{
+	cm_get(ctx)->no_wait = no_wait;
 }

--- a/src/vmod_curl.vcc
+++ b/src/vmod_curl.vcc
@@ -46,3 +46,6 @@ $Function VOID proxy(STRING)
 
 $Function VOID set_proxy(STRING)
 $Function VOID set_method(STRING)
+
+# Set = 1 for the fire & forget mode, 0 (default) otherwise
+$Function VOID set_no_wait(INT)

--- a/vmod-curl.spec
+++ b/vmod-curl.spec
@@ -1,13 +1,13 @@
 Summary: CURL support for Varnish VCL
 Name: vmod-curl
-Version: 0.1
+Version: 0.2
 Release: 1%{?dist}
 License: BSD
 Group: System Environment/Daemons
 Source0: libvmod-curl.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires: varnish >= 4.0
-BuildRequires: make, python-docutils, curl-devel > 7.19.0
+Requires: varnish >= 4.0, libuv
+BuildRequires: make, python-docutils, curl-devel > 7.19.0, libuv-devel
 
 %description
 CURL support for Varnish VCL
@@ -35,3 +35,5 @@ rm -rf %{buildroot}
 %changelog
 * Tue Nov 14 2012 Lasse Karstensen <lasse@varnish-software.com> - 0.1-0.20121114
 - Initial version.
+* Thu Nov 13 2014 Waldek Kozba <100assc@gmail.com> - 0.2-0.20141113
+- Added dependencies for libuv.

--- a/vmod-curl.spec
+++ b/vmod-curl.spec
@@ -33,7 +33,7 @@ rm -rf %{buildroot}
 %{_mandir}/man?/*
 
 %changelog
-* Tue Nov 14 2012 Lasse Karstensen <lasse@varnish-software.com> - 0.1-0.20121114
-- Initial version.
 * Thu Nov 13 2014 Waldek Kozba <100assc@gmail.com> - 0.2-0.20141113
 - Added dependencies for libuv.
+* Tue Nov 14 2012 Lasse Karstensen <lasse@varnish-software.com> - 0.1-0.20121114
+- Initial version.


### PR DESCRIPTION
Hi,

this commit introduces the asynchronous cURL, as we discussed in #19.
1. All transfer functions use the *multi interface*, so they work asynchronously.
2. The response related functions wait until the response is ready.
3. You can do any number of tasks between the transfer call (like get,post) and a first call to any of the response related functions (like status, header).
4. The transfer function call and corresponding response related function call can be spread through different VCL subroutines
5. There's a *no_wait* option provided (the new *set_no_wait* function in the module interface), for the *fire & forget* mode.
6. All previous VTC tests (unchanged) are passing
7. Additionally 2 tests are provided:
- test09.vtc - proves the asynchronous capability as stated in points 1 to 4
- test10.vtc - checks the 'no_wait' option (point 5)

Some highlights:

- the *cURL multi interface* is used with the asynchronous socket IO option (the *MULTI_SOCKET* option, see: http://curl.haxx.se/libcurl/c/libcurl-multi.html), which allowed to serve efficiently a large numbers of simultaneous cURL calls in a single multi interface thread
- the *libuv* (https://github.com/joyent/libuv) is used for the socket/time event handling. This gives an abstraction for the OS dependent scalable event multiplexing (thus portability).
Requires *libuv-devel* package for build, and/or *libuv* for runtime, which one can install as following:
```
yum install libuv libuv-devel
```
for CentOS, or
```
sudo apt-get install libuv-dev
```
for Ubuntu
- stress tests were performed on different virtual box'es (CentOS 6.5, CentOS 7 and Ubuntu 13.10), showing no issues with the module.
  - 500 requests /s, 
  - 2 cURL calls per request (one of them in *no_wait* mode)

Known issues:
- timeouts are not served properly by the multi-interface in the cURL version 7.19.7 (current RedHat/Centos 6 package). Don't exactly know in which cURL version this was fixed, but it's not an issue anymore in 7.32.0 (Ubuntu 13.10) or in 7.29.0 (CentOS 7).
One is able to solve it on CentOS 6 by upgrading to higher version of libcurl, eg. to the latest (I can confirm that it works), using eg. the city-fan.org repo:
```
rpm -Uvh http://www.city-fan.org/ftp/contrib/yum-repo/city-fan.org-release-1-12.rhel6.noarch.rpm
yum install libcurl
```

Best regards,

Waldek