### PR TITLE
Build for varnish4 on Debian.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Makefile.in
 /ltmain.sh
 /missing
 /stamp-h1
+/m4/
 
 /src/vcc_if.c
 /src/vcc_if.h

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ Makefile.in
 /ltmain.sh
 /missing
 /stamp-h1
-/m4/
 
 /src/vcc_if.c
 /src/vcc_if.h

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ VARNISH_VMOD_DIR
 VARNISH_VMODTOOL
 
 AC_PATH_PROG([VARNISHTEST], [varnishtest])
-AC_PATH_PROG([VARNISHD], [varnishd])
+AC_PATH_PROG([VARNISHD], [varnishd], [varnishd], [/sbin:/usr/sbin:/usr/local/sbin:$PATH])
 
 # check if curl supports ms timeout settings
 save_CFLAGS="${CFLAGS}"

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: libvmod-curl
 Section: web
 Priority: extra
 Maintainer: Lasse Karstensen <lkarsten@varnish-software.com>
-Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev
+Build-Depends: debhelper (>= 7), build-essential, python-docutils, libcurl4-gnutls-dev, libvarnishapi-dev (>= 4)
 Standards-Version: 3.8.1
 Vcs-Git: git://github.com/varnish/libvmod-curl.git
 
 Package: libvmod-curl
 Architecture: any
-Depends: varnish, ${misc:Depends}
+Depends: varnish (>= 4), ${shlibs:Depends}, ${misc:Depends}
 Description: CURL for Varnish VCL

--- a/debian/dirs
+++ b/debian/dirs
@@ -1,0 +1,2 @@
+usr/share/doc/libvmod-curl
+usr/lib/varnish/vmods

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@ override_dh_gencontrol:
 	fi
 
 %:
-	dh $@
+	dh $@ --with autoreconf


### PR DESCRIPTION
Allows building of libvmod_curl on Debian, including runnning all tests. 