### PR TITLE
Workaround to allow using the VMOD in vcl_backend_.* subroutines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 This vmod provides cURL bindings for Varnish so you can use Varnish
 as an HTTP client and fetch headers and bodies from backends.
 
+WARNING: a temporary workaround to allow using the VMOD in vcl_backend_.*
+subroutines has been added (see https://github.com/varnish/libvmod-curl/issues/23).
+The VMOD behaves as usual, but you should always complete execution of each
+cURL request during a single VCL phase (i.e. vcl_recv, vcl_backed_response,
+vcl_deliver, etc.). Otherwise, some unexpected behavior may arise. Anyway,
+this is the usual approach when using the VMOD.
+
 Usage:
 
 ./configure

--- a/src/vmod_curl.c
+++ b/src/vmod_curl.c
@@ -148,31 +148,31 @@ cm_make_key()
 static struct vmod_curl *
 cm_get(const struct vrt_ctx *ctx)
 {
-    struct vmod_curl *cm = pthread_getspecific(cl_key);
+	struct vmod_curl *cm = pthread_getspecific(cl_key);
 
-    unsigned vxid;
-    if (ctx->bo != NULL && ctx->req == NULL) {
-        CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
-        vxid = ctx->bo->vsl->wid;
-    } else {
-        CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
-        vxid = ctx->req->vsl->wid;
-    }
+	unsigned vxid;
+	if (ctx->bo != NULL && ctx->req == NULL) {
+		CHECK_OBJ_NOTNULL(ctx->bo, BUSYOBJ_MAGIC);
+		vxid = ctx->bo->vsl->wid;
+	} else {
+		CHECK_OBJ_NOTNULL(ctx->req, REQ_MAGIC);
+		vxid = ctx->req->vsl->wid;
+	}
 
-    if (cm == NULL) {
-        cm = malloc(sizeof(struct vmod_curl));
-        AN(cm);
+	if (cm == NULL) {
+		cm = malloc(sizeof(struct vmod_curl));
+		AN(cm);
 
-        cm_init(cm);
-        cm->vxid = vxid;
+		cm_init(cm);
+		cm->vxid = vxid;
 
-        pthread_setspecific(cl_key, cm);
-    }
+		pthread_setspecific(cl_key, cm);
+	}
 
-    if (cm->vxid != vxid) {
+	if (cm->vxid != vxid) {
 		cm_clear(cm);
 		cm->vxid = vxid;
-    }
+	}
 
 	return (cm);
 }


### PR DESCRIPTION
A temporary workaround to allow using the VMOD in `vcl_backend_.*` subroutines has been added (see https://github.com/varnish/libvmod-curl/issues/23). The VMOD behaves as usual, but you should always complete execution of each cURL request during a single VCL phase (i.e. `vcl_recv`, `vcl_backed_response`, `vcl_deliver`, etc.). Otherwise, some unexpected behavior may arise. Anyway, this is the usual approach when using the VMOD.
