### PR TITLE
Add debug_flags.h to the sources in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,7 +10,8 @@ libvmod_curl_la_LDFLAGS = -module -export-dynamic -avoid-version -shared \
 libvmod_curl_la_SOURCES = \
 	vcc_if.c \
 	vcc_if.h \
-	vmod_curl.c
+	vmod_curl.c \
+	debug_flags.h
 
 dist_man_MANS = vmod_curl.3
 MAINTAINERCLEANFILES = $(dist_man_MANS)


### PR DESCRIPTION
The tarball created by `make dist` does not compile now, the `src/debug_flags.h` header file was not included in the Makefile.

@Dridi : I'd like to remove the 1.0.4 tag, get this PR merged, and re-tag it as 1.0.4