### PR TITLE
Fix the build badge display issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-.. image:: https://travis-ci.org/varnish/libvmod-curl.svg?branch=4.1
+.. image:: https://travis-ci.org/varnish/libvmod-curl.svg?branch=master
    :alt: Travis CI badge
    :target: https://travis-ci.org/varnish/libvmod-curl/
 


### PR DESCRIPTION
Looks like the travis badge is pointing to `4.1` branch, putting it to `master`