### PR TITLE
fix chunked encoding in test13.vtc

### DIFF
--- a/src/tests/test13.vtc
+++ b/src/tests/test13.vtc
@@ -32,7 +32,7 @@ client c1 {
 	send "Transfer-Encoding: chunked\r\n"
 	send "\r\n"
 	send "3\r\n"
-	send "foo"
+	send "foo\r\n"
 	send "0\r\n"
 	send "\r\n"
 	rxresp


### PR DESCRIPTION
This is now properly validated by varnish-cache